### PR TITLE
Added command for viewing all revisions

### DIFF
--- a/src/GalaxyWiki.CLI/ApiClient.cs
+++ b/src/GalaxyWiki.CLI/ApiClient.cs
@@ -155,7 +155,7 @@ public static class ApiClient
             List<Revision>? revisions = JsonSerializer
                 .Deserialize<List<Revision>>(jsonString, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
-            return revisions ?? new List<Revision>();
+            return revisions ?? [];
         }
         catch (Exception ex)
         {

--- a/src/GalaxyWiki.CLI/ApiClient.cs
+++ b/src/GalaxyWiki.CLI/ApiClient.cs
@@ -139,6 +139,31 @@ public static class ApiClient
         }
     }
 
+    public static async Task<List<Revision>> GetRevisionsByBodyNameAsync(string bodyName)
+    {
+        try
+        {
+            // Performing the HTTP GET request
+            string endpoint = $"/api/revision/by-name/{Uri.EscapeDataString(bodyName)}";
+            HttpResponseMessage response = await httpClient.GetAsync(apiUrl + endpoint);
+            response.EnsureSuccessStatusCode();
+
+            // Reading the JSON response string
+            string jsonString = await response.Content.ReadAsStringAsync();
+
+            // Deserialising the JSON into a List<Revision> object
+            List<Revision>? revisions = JsonSerializer
+                .Deserialize<List<Revision>>(jsonString, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return revisions ?? new List<Revision>();
+        }
+        catch (Exception ex)
+        {
+            TUI.Err("GET", "Couldn't retrieve revisions", ex.Message);
+            return new List<Revision>();
+        }
+    }
+
     // Get comments for a celestial body
     public static async Task<List<Comment>> GetCommentsByCelestialBodyAsync(int celestialBodyId)
     {

--- a/src/GalaxyWiki.CLI/Program.cs
+++ b/src/GalaxyWiki.CLI/Program.cs
@@ -904,7 +904,7 @@ namespace GalaxyWiki.Cli
         static async Task HandleRevisionCommand(string args)
         {
             // Parse arguments to check for -n or --name flag
-            var argParts = args.Split(new[] { ' ' }, 2, StringSplitOptions.RemoveEmptyEntries);
+            var argParts = args.Split([' '], 2, StringSplitOptions.RemoveEmptyEntries);
             
             // Check if a specific celestial body was requested
             if (argParts.Length == 2 && (argParts[0].Equals("-n", StringComparison.OrdinalIgnoreCase) || 
@@ -938,7 +938,7 @@ namespace GalaxyWiki.Cli
             {
                 var revisions = await ApiClient.GetRevisionsByBodyNameAsync(bodyName);
                 
-                if (revisions == null || !revisions.Any())
+                if (revisions == null || revisions.Count == 0)
                 {
                     TUI.Err("REVISION", $"No revisions found for '{bodyName}'.");
                     return;
@@ -955,7 +955,7 @@ namespace GalaxyWiki.Cli
                 foreach (var revision in revisions.OrderByDescending(r => r.CreatedAt))
                 {
                     var previewContent = revision.Content?.Length > 50 
-                        ? revision.Content.Substring(0, 50) + "..." 
+                        ? revision.Content[..50] + "..." 
                         : revision.Content ?? "";
                     
                     table.AddRow(

--- a/src/GalaxyWiki.CLI/Program.cs
+++ b/src/GalaxyWiki.CLI/Program.cs
@@ -94,6 +94,8 @@ namespace GalaxyWiki.Cli
 
                     case "login": await ApiClient.LoginAsync(); break;
 
+                    case "revision": await HandleRevisionCommand(dat); break;
+
                     default: HandleUnknownCommand(cmd); break;
                 }
             }
@@ -897,6 +899,80 @@ namespace GalaxyWiki.Cli
         static string JoinArgs(List<string> args)
         {
             return string.Join(" ", args);
+        }
+
+        static async Task HandleRevisionCommand(string args)
+        {
+            // Parse arguments to check for -n or --name flag
+            var argParts = args.Split(new[] { ' ' }, 2, StringSplitOptions.RemoveEmptyEntries);
+            
+            // Check if a specific celestial body was requested
+            if (argParts.Length == 2 && (argParts[0].Equals("-n", StringComparison.OrdinalIgnoreCase) || 
+                                         argParts[0].Equals("--name", StringComparison.OrdinalIgnoreCase)))
+            {
+                string bodyName = CommandLogic.TrimQuotes(argParts[1]);
+                await ShowRevisionsForNamedBody(bodyName);
+                return;
+            }
+            
+            // If no specific body was requested, show revisions for current location
+            await ShowRevisionsForCurrentLocation();
+        }
+        
+        static async Task ShowRevisionsForCurrentLocation()
+        {
+            var body = CommandLogic.GetCurrentBody();
+            
+            if (body == null)
+            {
+                TUI.Err("REVISION", "No celestial body found at current location.");
+                return;
+            }
+            
+            await ShowRevisionsForNamedBody(body.BodyName);
+        }
+        
+        static async Task ShowRevisionsForNamedBody(string bodyName)
+        {
+            try
+            {
+                var revisions = await ApiClient.GetRevisionsByBodyNameAsync(bodyName);
+                
+                if (revisions == null || !revisions.Any())
+                {
+                    TUI.Err("REVISION", $"No revisions found for '{bodyName}'.");
+                    return;
+                }
+                
+                var table = new Table()
+                    .Border(TableBorder.Rounded)
+                    .BorderColor(Color.Grey)
+                    .AddColumn(new TableColumn("ID").LeftAligned())
+                    .AddColumn(new TableColumn("Created At").LeftAligned())
+                    .AddColumn(new TableColumn("Author").LeftAligned())
+                    .AddColumn(new TableColumn("Preview").LeftAligned());
+                
+                foreach (var revision in revisions.OrderByDescending(r => r.CreatedAt))
+                {
+                    var previewContent = revision.Content?.Length > 50 
+                        ? revision.Content.Substring(0, 50) + "..." 
+                        : revision.Content ?? "";
+                    
+                    table.AddRow(
+                        revision.Id.ToString(),
+                        revision.CreatedAt.ToString("yyyy-MM-dd HH:mm"),
+                        revision.AuthorDisplayName ?? "Unknown",
+                        previewContent
+                    );
+                }
+                
+                AnsiConsole.Write(new Rule($"[gold3]Revision History for {bodyName}[/]"));
+                AnsiConsole.Write(table);
+            }
+            catch (Exception ex)
+            {
+                TUI.Err("REVISION", $"Failed to retrieve revisions for '{bodyName}'", ex.Message);
+            }
         }
     }
 }

--- a/src/GalaxyWiki.CLI/TUI.cs
+++ b/src/GalaxyWiki.CLI/TUI.cs
@@ -472,4 +472,34 @@ public static class TUI {
         return selection;
     }
 
+    public static void ShowHelp()
+    {
+        AnsiConsole.Clear();
+        AnsiConsole.Write(new FigletText("GalaxyWiki CLI").Centered());
+        AnsiConsole.WriteLine();
+        
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .BorderColor(Color.Grey)
+            .AddColumn(new TableColumn("Command").LeftAligned())
+            .AddColumn(new TableColumn("Description").LeftAligned());
+            
+        table.AddRow("cd <path>", "Navigate to a celestial body");
+        table.AddRow("ls", "List bodies in current location");
+        table.AddRow("info, show", "Show info about current location");
+        table.AddRow("show -n <name>", "Show info about a specific body");
+        table.AddRow("render", "Show visual representation of current body");
+        table.AddRow("pwd", "Print current path");
+        table.AddRow("comment <text>", "Add a comment to the current body");
+        table.AddRow("revision", "Show revision history for current body");
+        table.AddRow("revision -n <name>", "Show revision history for a specific body");
+        table.AddRow("find <term>", "Search for celestial bodies");
+        table.AddRow("create", "Create a new revision for current body");
+        table.AddRow("edit", "Edit the current body's content");
+        table.AddRow("login", "Login to the system");
+        table.AddRow("exit, quit", "Exit the application");
+        
+        AnsiConsole.Write(table);
+    }
+
 }


### PR DESCRIPTION
You can type:
- `revision` to view all the revisions for the current celestial body
- `revision -n <body name>` or `revision --name <body name>` to view all the revision for the named body